### PR TITLE
Reworked store/training plumbing. Updated example and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ You can see an example program below. It first creates a Hopfield network patter
 func main() {
         pattern := hopfield.Encode([]float64{0.2, -12.4, 0.0, 3.4})
         // Create new Hopfield Network and set its size to the length of pattern
-	n, err := hopfield.NewNet(len(pattern))
+	n, err := hopfield.NewNet(len(pattern), "hebbian")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
         fmt.Println("Storing:", pattern)
 	// store patterns in Hopfield network
-	if err := n.Store([]hopfield.Pattern{pattern}, "hebbian"); err != nil {
+	if err := n.Store([]hopfield.Pattern{pattern}); err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
@@ -77,7 +77,7 @@ $  _build/mnist -h
 Example run:
 
 ```
-$ _build/mnist -eqiters 40 -maxiters 100 -datadir ./examples/mnist/patterns/ -output out.png -learning "storkey"
+$ _build/mnist -eqiters 40 -maxiters 100 -datadir ./examples/mnist/patterns/ -output out.png -training "storkey"
 ```
 
 This will generate two files in directory: `noisy.png` and `out.png`.

--- a/README.md
+++ b/README.md
@@ -28,27 +28,27 @@ You can see an example program below. It first creates a Hopfield network patter
 
 ```go
 func main() {
-        pattern := hopfield.Encode([]float64{0.2, -12.4, 0.0, 3.4})
-        // Create new Hopfield Network and set its size to the length of pattern
+	pattern := hopfield.Encode([]float64{0.2, -12.4, 0.0, 3.4})
+	// Create new Hopfield Network and set its size to the length of pattern
 	n, err := hopfield.NewNet(len(pattern), "hebbian")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
-        fmt.Println("Storing:", pattern)
+	fmt.Println("Storing:", pattern)
 	// store patterns in Hopfield network
 	if err := n.Store([]hopfield.Pattern{pattern}); err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
 
-        // restore image from Hopfield network
+	// restore image from Hopfield network
 	res, err := n.Restore(pattern, 20, 10)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
-        fmt.Println("Restored:", res)
+	fmt.Println("Restored:", res)
 }
 ```
 

--- a/hopfield/network_test.go
+++ b/hopfield/network_test.go
@@ -18,12 +18,17 @@ func TestChangeStateNeuron(t *testing.T) {
 func TestNewnet(t *testing.T) {
 	assert := assert.New(t)
 
+	method := "storkey"
 	size := 5
-	n, err := NewNet(size)
+	n, err := NewNet(size, method)
 	assert.NotNil(n)
 	assert.NoError(err)
 
-	n, err = NewNet(-2)
+	n, err = NewNet(-2, method)
+	assert.Nil(n)
+	assert.Error(err)
+
+	n, err = NewNet(size, "foobar")
 	assert.Nil(n)
 	assert.Error(err)
 }
@@ -31,8 +36,9 @@ func TestNewnet(t *testing.T) {
 func TestNeurons(t *testing.T) {
 	assert := assert.New(t)
 
+	method := "storkey"
 	size := 5
-	n, err := NewNet(size)
+	n, err := NewNet(size, method)
 	assert.NotNil(n)
 	assert.NoError(err)
 
@@ -43,8 +49,9 @@ func TestNeurons(t *testing.T) {
 func TestWeights(t *testing.T) {
 	assert := assert.New(t)
 
+	method := "storkey"
 	size := 5
-	n, err := NewNet(size)
+	n, err := NewNet(size, method)
 	assert.NotNil(n)
 	assert.NoError(err)
 
@@ -57,8 +64,9 @@ func TestWeights(t *testing.T) {
 func TestBias(t *testing.T) {
 	assert := assert.New(t)
 
+	method := "storkey"
 	size := 5
-	n, err := NewNet(size)
+	n, err := NewNet(size, method)
 	assert.NotNil(n)
 	assert.NoError(err)
 
@@ -71,34 +79,33 @@ func TestBias(t *testing.T) {
 func TestStore(t *testing.T) {
 	assert := assert.New(t)
 
-	method := "hebbian"
 	size := 4
-	n, err := NewNet(size)
+	// Hebbian learning
+	n, err := NewNet(size, "hebbian")
 	assert.NotNil(n)
 	assert.NoError(err)
 
 	var patterns []Pattern
-	errString := "invalid pattern supplied: %v"
-	err = n.Store(patterns, method)
+	errString := "invalid patterns supplied: %v"
+	err = n.Store(patterns)
 	assert.EqualError(err, fmt.Sprintf(errString, patterns))
 
 	patterns = []Pattern{Pattern{1.0, -1.0}}
-	errString = "Dimension mismatch: %v"
-	err = n.Store(patterns, method)
-	assert.EqualError(err, fmt.Sprintf(errString, patterns))
+	errString = "pattern dimension mismatch: %v"
+	err = n.Store(patterns)
+	assert.EqualError(err, fmt.Sprintf(errString, patterns[0]))
 
 	patterns = []Pattern{Pattern{1.0, -1.0, -1.0, 1.0}}
-	err = n.Store(patterns, method)
+	err = n.Store(patterns)
 	assert.NoError(err)
 	assert.Equal(n.Weights().At(0, 3), n.Weights().At(3, 0))
 
-	// this makes no sense semantically, but it will do for the test
-	err = n.Store(patterns, "storkey")
+	// Storkey learning
+	n, err = NewNet(size, "storkey")
+	assert.NotNil(n)
 	assert.NoError(err)
-	assert.Equal(n.Weights().At(0, 3), n.Weights().At(3, 0))
 
-	// this makes no sense semantically, but it will do for the test
-	err = n.Store(patterns, "foobar")
+	err = n.Store(patterns)
 	assert.NoError(err)
 	assert.Equal(n.Weights().At(0, 3), n.Weights().At(3, 0))
 }
@@ -110,12 +117,12 @@ func TestRestore(t *testing.T) {
 	maxiters := 10
 	eqiters := 5
 	method := "hebbian"
-	n, err := NewNet(size)
+	n, err := NewNet(size, method)
 	assert.NotNil(n)
 	assert.NoError(err)
 
 	patterns := []Pattern{Pattern{1.0, -1.0, -1.0, 1.0}}
-	err = n.Store(patterns, method)
+	err = n.Store(patterns)
 	assert.NoError(err)
 
 	pattern := Pattern(nil)
@@ -125,7 +132,7 @@ func TestRestore(t *testing.T) {
 	assert.EqualError(err, fmt.Sprintf(errString, pattern))
 
 	pattern = Pattern{1.0, -1.0}
-	errString = "Dimension mismatch: %v"
+	errString = "dimension mismatch: %v"
 	res, err = n.Restore(pattern, maxiters, eqiters)
 	assert.Nil(res)
 	assert.EqualError(err, fmt.Sprintf(errString, pattern))
@@ -159,7 +166,8 @@ func TestEnergy(t *testing.T) {
 	assert := assert.New(t)
 
 	size := 4
-	n, err := NewNet(size)
+	method := "hebbian"
+	n, err := NewNet(size, method)
 	assert.NotNil(n)
 	assert.NoError(err)
 
@@ -175,7 +183,7 @@ func TestEnergy(t *testing.T) {
 	assert.EqualError(err, fmt.Sprintf(errString, pattern))
 
 	pattern = Pattern{1.0, -1.0}
-	errString = "Dimension mismatch: %v"
+	errString = "dimension mismatch: %v"
 	energy, err = n.Energy(pattern)
 	assert.Equal(0.0, energy)
 	assert.EqualError(err, fmt.Sprintf(errString, pattern))


### PR DESCRIPTION
Store no longer accepts storage method. Method parameter is now part of `Network` initialization. This helps to avoid mixing up different training methods for the same network. This is a major change which had the following effect on the underlying code:

1. Training method is immutable and specified when the network is
created
2. Store Hebbian/Storkey are no longer network methods, bur rather
separate functions