### PR TITLE
Improved Pattern API, added differeent network modes and trainings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,28 +27,37 @@ $ make test
 You can see an example program below. It first creates a Hopfield network pattern based on arbitrary data. The data is encoded into binary values of +1/-1 (see the documentation) using `Encode` function. It is then stored in the network and then restored.
 
 ```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/milosgajdos83/gopfield/hopfield"
+)
+
 func main() {
 	pattern := hopfield.Encode([]float64{0.2, -12.4, 0.0, 3.4})
 	// Create new Hopfield Network and set its size to the length of pattern
-	n, err := hopfield.NewNet(len(pattern), "hebbian")
+	n, err := hopfield.NewNetwork(pattern.Len(), "hebbian")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
-	fmt.Println("Storing:", pattern)
+	fmt.Printf("Storing: \n%v\n\n", pattern)
 	// store patterns in Hopfield network
-	if err := n.Store([]hopfield.Pattern{pattern}); err != nil {
+	if err := n.Store([]*hopfield.Pattern{pattern}); err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
 
 	// restore image from Hopfield network
-	res, err := n.Restore(pattern, 20, 10)
+	res, err := n.Restore(pattern, "async", 10)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\nERROR: %s\n", err)
 		os.Exit(1)
 	}
-	fmt.Println("Restored:", res)
+	fmt.Printf("Restored: \n%v\n", res)
 }
 ```
 
@@ -56,8 +65,17 @@ If you run this program, you will see the pattern being reconstructed correctly:
 
 ```
 $ go run main.go
-Storing: [1 -1 -1 1]
-Restored: [1 -1 -1 1]
+Storing:
+⎡ 1⎤
+⎢-1⎥
+⎢-1⎥
+⎣ 1⎦
+
+Restored:
+⎡ 1⎤
+⎢-1⎥
+⎢-1⎥
+⎣ 1⎦
 ```
 
 You can find a more elaborate example in the `examples` directory of the project. There is a mnist example which tries to reconstruct a corrupted image loaded from the `patterns` subdirectory which contains two [MNIST](http://yann.lecun.com/exdb/mnist/) images: 0 and 4. These are stored in the Hopfield neural network. The mnist program then picks image `4` and adds some random noise to it. Finallys, it tries to reconstruct the original image from the network. See below how to use the example program:
@@ -77,7 +95,7 @@ $  _build/mnist -h
 Example run:
 
 ```
-$ _build/mnist -eqiters 40 -maxiters 100 -datadir ./examples/mnist/patterns/ -output out.png -training "storkey"
+$ _build/mnist -mode "async" -iters 1 -datadir ./examples/mnist/patterns/ -output out.png -training "storkey"
 ```
 
 This will generate two files in directory: `noisy.png` and `out.png`.

--- a/hopfield/network.go
+++ b/hopfield/network.go
@@ -2,252 +2,248 @@ package hopfield
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
+	"strings"
 
 	"github.com/gonum/matrix/mat64"
 )
 
-// Neuron is Hopfield network unit
-type Neuron struct {
-	// state is neuron's state: +1/-1
-	state float64
-}
-
-// ChangeState changes the state of Neuron and returns true if the state has changed. Otherwise it returns false.
-func (n *Neuron) ChangeState(state float64) bool {
-	if state*n.state < 0.0 {
-		n.state = -n.state
-		return true
-	}
-
-	return false
-}
-
-// StoreFunc stores creates symmetric matrix from supplied patterns ard returns it
-type StoreFunc func([]Pattern) mat64.Symmetric
-
-// trainMethod lists supported training methods
-var store = map[string]StoreFunc{
-	"hebbian": hebbian,
-	"storkey": storkey,
-}
-
-// Net is Hopfield network
-type Net struct {
-	// network neurons
-	neurons []*Neuron
+// Network is Hopfield network
+type Network struct {
 	// weights are network neurons weights
 	weights *mat64.SymDense
 	// bias are network unit direct inputs
 	bias *mat64.Vector
-	// store function based on training type
-	storeFunc StoreFunc
+	// method is training method
+	method string
+	// memorised keeps a count of memorized patterns
+	memorised int
 }
 
-// NewNet creates a new Hopfield network which is trained using the requested training method and returns it.
-// NewNet returns error if either non-positive size is supplied or unsupported training method is supplied.
-func NewNet(size int, method string) (*Net, error) {
+// NewNetwork creates new Hopfield network which is trained using the training method and returns it.
+// NewNetwork returns error if either non-positive size is supplied or unsupported training method is supplied.
+func NewNetwork(size int, method string) (*Network, error) {
 	// can't have negative number of weights
 	if size <= 0 {
 		return nil, fmt.Errorf("invalid network size: %d", size)
 	}
 	// if unsupported method is supplied we return error
-	storeFunc, ok := store[method]
-	if !ok {
+	if !strings.EqualFold("hebbian", method) && !strings.EqualFold("storkey", method) {
 		return nil, fmt.Errorf("unsupported training method: %s", method)
-	}
-	// allocate neurons slice and iitialize it
-	neurons := make([]*Neuron, size)
-	for i := range neurons {
-		neurons[i] = new(Neuron)
 	}
 	// allocate weights and bias matrices
 	weights := mat64.NewSymDense(size, nil)
 	bias := mat64.NewVector(size, nil)
 
-	return &Net{
-		neurons:   neurons,
-		weights:   weights,
-		bias:      bias,
-		storeFunc: storeFunc,
+	return &Network{
+		weights: weights,
+		bias:    bias,
+		method:  method,
 	}, nil
 }
 
-// Neurons returns a slice of network neurons
-func (n Net) Neurons() []*Neuron {
-	return n.neurons
-}
-
 // Weights returns network weights
-func (n Net) Weights() mat64.Symmetric {
+func (n Network) Weights() mat64.Matrix {
 	return n.weights
 }
 
 // Bias returns network bias
-func (n Net) Bias() mat64.Matrix {
+func (n Network) Bias() mat64.Matrix {
 	return n.bias
 }
 
+// Capacity returns network capacity
+func (n Network) Capacity() int {
+	// c is a number of neurons
+	_, c := n.weights.Dims()
+	// storkey learning gives higher capacity
+	if strings.EqualFold("storkey", n.method) {
+		return int(math.Floor(float64(c) / (2 * math.Sqrt(math.Log(float64(c))))))
+	}
+
+	return int(math.Floor(float64(c) / (2 * math.Log(float64(c)))))
+}
+
+// Memorised returns count of memorised patterns
+func (n Network) Memorised() int {
+	return n.memorised
+}
+
 // Store stores supplied patterns in network.
-// Store returns error if patterns is nil or if any of the supplied data patterns do not have the same dimension as network neurons.
-func (n *Net) Store(patterns []Pattern) error {
+// Store returns error if patterns is nil or if any of the patterns do not have the same dimension as number network neurons.
+func (n *Network) Store(patterns []*Pattern) error {
 	// patterns can't be nil
 	if patterns == nil || len(patterns) == 0 {
 		return fmt.Errorf("invalid patterns supplied: %v", patterns)
 	}
+	_, nCount := n.weights.Dims()
 	// each pattern length must be the same as number of neurons
 	for _, p := range patterns {
-		if len(p) != len(n.neurons) {
-			return fmt.Errorf("pattern dimension mismatch: %v", p)
+		// nil patterns are invalid
+		if p == nil {
+			return fmt.Errorf("invalid pattern supplied: %v", p)
+		}
+		// incorrect dimension
+		if p.Len() != nCount {
+			return fmt.Errorf("invalid pattern dimension: %d", p.Len())
 		}
 	}
-	// add weights matrices to the network one
-	n.weights.AddSym(n.weights, n.storeFunc(patterns))
+	// store patterns in the network
+	switch n.method {
+	case "hebbian":
+		n.storeHebbian(patterns)
+	case "storkey":
+		n.storeStorkey(patterns)
+	}
 
 	return nil
 }
 
-// Restore tries to restore pattern from the patterns stored in the network.
-// It runs Hopfield network until either a local minima (eqiters) or maxiters number of iterations has been reached.
-// Restore modifies p in place so the returned pattern is closest to any of the patterns stored in the network.
-// It returns error if the supplied pattern is nil or if it does not have the same dimension as number of network neurons.
-func (n *Net) Restore(p Pattern, maxiters, eqiters int) (Pattern, error) {
+// Restore tries to restore supplied pattern from network through mode restore process and returns it.
+// Mode can be either sync or async. If sync mode is requested, iters parameter is ignored.
+// If async mode is requested network runs for iters iterations and returns the restored pattern.
+// It returns error if invalid patterns is supplied, iters is negative or unsupported mode is supplied.
+func (n *Network) Restore(p *Pattern, mode string, iters int) (*Pattern, error) {
 	// pattern can't be nil
 	if p == nil {
 		return nil, fmt.Errorf("invalid pattern supplied: %v", p)
 	}
 	// pattern length must be the same as number of neurons
-	if len(p) != len(n.neurons) {
-		return nil, fmt.Errorf("dimension mismatch: %v", p)
+	_, nCount := n.weights.Dims()
+	if p.Len() != nCount {
+		return nil, fmt.Errorf("invalid pattern dimension: %v", p.Len())
 	}
 	// number of max iterations must be a positive integer
-	if maxiters <= 0 {
-		return nil, fmt.Errorf("invalid number of max iterations: %d", maxiters)
+	if strings.EqualFold("async", mode) && iters <= 0 {
+		return nil, fmt.Errorf("invalid number of iterations: %d", iters)
 	}
-	// number of equlibrium iterations must be a positive integer
-	if eqiters <= 0 {
-		return nil, fmt.Errorf("invalid number of equilibrium iterations: %d", eqiters)
-	}
-	// set neurons states to the pattern
-	for i, neuron := range n.neurons {
-		neuron.state = p[i]
-	}
-	// we will bound the number of iterations to eqiters and maxiters
-	eqiter, maxiter := 0, 0
-	for maxiter < maxiters {
-		// generate pseudorandom sequence
-		seq := rand.Perm(len(n.neurons))
-		for _, i := range seq {
-			sum := 0.0
-			for j := 0; j < len(n.neurons); j++ {
-				// some all connections to j-th neuron
-				sum += n.weights.At(i, j) * p[j]
-			}
-			// update pattern based on result
-			switch {
-			case sum >= n.bias.At(i, 0):
-				p[i] = 1.0
-			default:
-				p[i] = -1.0
-			}
-			// update neuron if its state has changed
-			switch n.neurons[i].ChangeState(p[i]) {
-			case true:
-				// if the network state changed, reset the counter
-				eqiter = 0
-			default:
-				// if the network state hasnt changed, we are around equlibrium
-				eqiter++
-			}
-			// if we are around equlibrium, exit
-			if eqiter == eqiters {
-				return p, nil
-			}
-		}
-		maxiter++
+	// only sync and async modes are allowed
+	switch mode {
+	case "sync":
+		return n.restoreSync(p)
+	case "async":
+		return n.restoreAsync(p, iters)
 	}
 
-	return p, nil
+	return nil, fmt.Errorf("unsupported mode: %s", mode)
 }
 
 // Energy calculates Hopfield network energy for a given pattern and returns it
 // It returns error if the supplied pattern is nil or if it does not have the same dimension as number of network neurons.
-func (n Net) Energy(p Pattern) (float64, error) {
+func (n Network) Energy(p *Pattern) (float64, error) {
 	// pattern can't be nil
 	if p == nil {
 		return 0.0, fmt.Errorf("invalid pattern supplied: %v", p)
 	}
 	// pattern length must be the same as number of neurons
-	if len(p) != len(n.neurons) {
-		return 0.0, fmt.Errorf("dimension mismatch: %v", p)
+	_, nCount := n.weights.Dims()
+	// incorrect dimension
+	if p.Len() != nCount {
+		return 0.0, fmt.Errorf("invalid pattern dimension: %v", p.Len())
 	}
+	// hopfield energy
+	energy := -0.5 * mat64.Inner(p.Vec(), n.weights, p.Vec())
+	energy += mat64.Dot(n.bias, p.Vec())
 
-	energy := 0.0
-	// traverse the network higher triangular weights matrix
-	for i := 0; i < len(n.neurons); i++ {
-		for j := i + 1; j < len(n.neurons); j++ {
-			energy += n.weights.At(i, j) * p[i] * p[j]
-		}
-	}
-	bias := 0.0
-	// calculate the bias additions
-	for i := 0; i < len(n.neurons); i++ {
-		bias += n.bias.RawVector().Data[i] * p[i]
-	}
-
-	return -(energy + bias), nil
+	return energy, nil
 }
 
 // hebbian uses Hebbian learning to generate weights matrix
-func hebbian(p []Pattern) mat64.Symmetric {
+func (n *Network) storeHebbian(patterns []*Pattern) {
 	// pattern dimension [same as nr. of neurons]
-	dim := len(p[0])
-	// weights matrix
-	weights := mat64.NewSymDense(dim, nil)
+	dim := patterns[0].Len()
+	// w stores partial weights for each pattern
+	w := mat64.NewSymDense(dim, nil)
 	// we only traverse higher triangular matrix because we are using Symmetric matrix
 	for i := 0; i < dim; i++ {
 		for j := i + 1; j < dim; j++ {
-			for k := range p {
-				weights.SetSym(i, j, weights.At(i, j)+p[k][i]*p[k][j]/float64(dim))
+			for _, p := range patterns {
+				w.SetSym(i, j, w.At(i, j)+(p.At(i)*p.At(j)/float64(dim)))
 			}
 		}
 	}
-
-	return weights
+	// Add nwe weights matrix to network weights matrix
+	n.weights.AddSym(n.weights, w)
 }
 
 // storkey uses Storkey learning to generate weights matrix
-func storkey(p []Pattern) mat64.Symmetric {
+func (n *Network) storeStorkey(patterns []*Pattern) {
 	// pattern dimension [same as nr. of neurons]
-	dim := len(p[0])
+	dim := patterns[0].Len()
 	// weights matrix
-	weights := mat64.NewSymDense(dim, nil)
-
+	w := mat64.NewSymDense(dim, nil)
+	// we only traverse higher triangular matrix because we are using Symmetric matrix
 	var sum float64
 	for i := 0; i < dim; i++ {
 		for j := i + 1; j < dim; j++ {
-			for k := range p {
-				sum = p[k][i] * p[k][j]
-				sum -= p[k][i] * localField(weights, p[k], j, i)
-				sum -= p[k][j] * localField(weights, p[k], i, j)
+			for _, p := range patterns {
+				sum = p.At(i) * p.At(j)
+				sum -= p.At(i) * localField(w, p, j, i)
+				sum -= p.At(j) * localField(w, p, i, j)
 				sum *= 1 / float64(dim)
-				weights.SetSym(i, j, weights.At(i, j)+sum)
+				w.SetSym(i, j, w.At(i, j)+sum)
 			}
 		}
 	}
-
-	return weights
+	// Add nwe weights matrix to network weights matrix
+	n.weights.AddSym(n.weights, w)
 }
 
 // localField calculates Storkey local field for a given pattern and returns it
-func localField(w mat64.Symmetric, p Pattern, i, j int) float64 {
+func localField(w *mat64.SymDense, p *Pattern, i, j int) float64 {
 	sum := 0.0
 	// calculate sum for all but i and j neuron weights
-	for k := 0; k < len(p); k++ {
+	for k := 0; k < p.Len(); k++ {
 		if k != i && k != j {
-			sum += w.At(i, k) * p[k]
+			// TODO: Raw access turns out to be slowe than library access WTF?!
+			//sum += w.RawSymmetric().Data[i*w.RawSymmetric().Stride+k] * p.At(k)
+			sum += w.At(i, k) * p.At(k)
 		}
 	}
 
 	return sum
+}
+
+// restoreSync restores patterns from the network synchronously
+func (n *Network) restoreSync(p *Pattern) (*Pattern, error) {
+	p.Vec().MulVec(n.weights, p.Vec())
+	for i := 0; i < p.Len(); i++ {
+		if p.At(i) >= n.bias.At(i, 0) {
+			p.RawData()[i] = 1.0
+		} else {
+			p.RawData()[i] = -1.0
+		}
+	}
+
+	return p, nil
+}
+
+// restoreAsync restores patterns from the network synchronously
+func (n *Network) restoreAsync(p *Pattern, iters int) (*Pattern, error) {
+	// we will bound the number of iterations to eqiters and maxiters
+	var nState float64
+	for iters > 0 {
+		// generate pseudorandom sequence
+		seq := rand.Perm(p.Len())
+		for _, i := range seq {
+			sum := 0.0
+			for j := 0; j < p.Len(); j++ {
+				// some all connections to j-th neuron
+				sum += n.weights.At(i, j) * p.At(j)
+			}
+			// if the sum is bigger than bias
+			if sum >= n.bias.At(i, 0) {
+				nState = 1.0
+			} else {
+				nState = -1.0
+			}
+			if p.At(i)*nState < 0.0 {
+				p.RawData()[i] = nState
+			}
+		}
+		iters--
+	}
+
+	return p, nil
 }

--- a/hopfield/pattern.go
+++ b/hopfield/pattern.go
@@ -1,47 +1,99 @@
 package hopfield
 
 import (
+	"fmt"
 	"image"
 	"image/draw"
 	"math/rand"
+
+	"github.com/gonum/matrix/mat64"
 )
 
 // Pattern is a data pattern
-type Pattern []float64
+type Pattern struct {
+	// v is a vector which stores binary data
+	v *mat64.Vector
+}
 
-// Encode encodes data to a pattern of values: +1/-1 where non-positive items are set to -1 and returns it.
-func Encode(data []float64) Pattern {
-	p := make(Pattern, len(data))
-	for i := 0; i < len(p); i++ {
+// String implements Stringer interface
+func (p *Pattern) String() string {
+	fa := mat64.Formatted(p.v, mat64.Prefix(""), mat64.Squeeze())
+	return fmt.Sprintf("%v", fa)
+}
+
+// Vec returns internal data vector
+func (p *Pattern) Vec() *mat64.Vector {
+	return p.v
+}
+
+// RawData returns pattern raw data
+func (p *Pattern) RawData() []float64 {
+	return p.v.RawVector().Data
+}
+
+// At returns valir of patttern on position i
+func (p *Pattern) At(i int) float64 {
+	return p.v.RawVector().Data[i]
+}
+
+// Set sets value on position i
+func (p *Pattern) Set(i int, val float64) error {
+	if i > p.v.Len() {
+		return fmt.Errorf("invalid index: %d", i)
+	}
+	// we transform vals to +1/-1
+	if val <= 0.0 {
+		p.v.RawVector().Data[i] = -1.0
+	} else {
+		p.v.RawVector().Data[i] = 1.0
+	}
+
+	return nil
+}
+
+// Len returns the length of the pattern
+func (p *Pattern) Len() int {
+	if p.v == nil {
+		return 0
+	}
+	return p.v.Len()
+}
+
+// Encode encodes data to a pattern of values: +1/-1. Non-positive data items are set to -1, positive ones are set to +1
+// Encode modifies the data slice in place and returns pointer to Pattern.
+func Encode(data []float64) *Pattern {
+	for i := 0; i < len(data); i++ {
 		if data[i] <= 0.0 {
-			p[i] = -1.0
+			data[i] = -1.0
 		} else {
-			p[i] = 1.0
+			data[i] = 1.0
 		}
+	}
+	v := mat64.NewVector(len(data), data)
+
+	return &Pattern{
+		v: v,
+	}
+}
+
+// AddNoise adds random noise to pattern p and returns it. Noise is added by flipping the sign of existing pattern value.
+// It allows to specify the percentage of noise via pcnt parameter. AddNoise modifies the pattern p in place.
+func AddNoise(p *Pattern, pcnt int) *Pattern {
+	n, _ := p.v.Dims()
+	for i := 0; i < n; i++ {
+		if i > (pcnt*n)/100 {
+			break
+		}
+		j := rand.Intn(n)
+		p.v.SetVec(j, -p.v.At(j, 0))
 	}
 
 	return p
 }
 
-// AddNoise adds random noise to pattern and returns it. Noise is added by flipping the sign of existing pattern value.
-// It allows to specify the percentage of noise via pcnt parameter. AddNoise does not modify the pattern in place.
-func AddNoise(p Pattern, pcnt int) Pattern {
-	np := make(Pattern, len(p))
-	copy(np, p)
-	for i := 0; i < len(np); i++ {
-		if i > (pcnt*len(np))/100 {
-			break
-		}
-		j := rand.Intn(len(np))
-		np[j] = -np[j]
-	}
-
-	return np
-}
-
 // Image2Pattern transforms img raw data into binary encoded pattern that can be used in Hopfield Network
 // It first turns the image into a Grey scaled image and then encodes its pixels into binary values of -1/+1
-func Image2Pattern(img image.Image) Pattern {
+func Image2Pattern(img image.Image) *Pattern {
 	// convert image to Gray scaled image
 	imGray := image.NewGray(image.Rect(0, 0, img.Bounds().Dx(), img.Bounds().Dy()))
 	draw.Draw(imGray, imGray.Bounds(), img, img.Bounds().Min, draw.Src)
@@ -54,13 +106,13 @@ func Image2Pattern(img image.Image) Pattern {
 	return Encode(pattern)
 }
 
-// Pattern2Image turns passed in Hopfield network pattern to a lossy Gray scaled image from pattern.
+// Pattern2Image turns pattern p to a *lossy* Gray scaled image.
 // Data to pixel transformation is lossy: non-positive elements are transformed to 0, otherwise 255
-func Pattern2Image(p Pattern, r image.Rectangle) image.Image {
+func Pattern2Image(p *Pattern, r image.Rectangle) image.Image {
 	// pix is a slice that contains pixels
-	pix := make([]byte, len(p))
-	for i := range p {
-		if p[i] <= 0.0 {
+	pix := make([]byte, len(p.v.RawVector().Data))
+	for i := range pix {
+		if p.v.At(i, 0) <= 0.0 {
 			pix[i] = 0
 		} else {
 			pix[i] = 255

--- a/hopfield/pattern_test.go
+++ b/hopfield/pattern_test.go
@@ -1,53 +1,122 @@
 package hopfield
 
 import (
+	"fmt"
 	"image"
 	"image/draw"
 	"testing"
 
+	"github.com/gonum/matrix/mat64"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestVec(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []float64{1.0, 2.0}
+	v := mat64.NewVector(len(data), data)
+	p := &Pattern{v: v}
+	assert.EqualValues(v, p.Vec())
+}
+
+func TestRawData(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []float64{1.0, 2.0}
+	v := mat64.NewVector(len(data), data)
+	p := &Pattern{v: v}
+	assert.EqualValues(p.RawData(), v.RawVector().Data)
+}
+
+func TestAt(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []float64{1.0, 2.0}
+	v := mat64.NewVector(len(data), data)
+	p := &Pattern{v: v}
+
+	assert.Equal(p.At(0), data[0])
+}
+
+func TestSet(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []float64{1.0, 2.0}
+	v := mat64.NewVector(len(data), data)
+	p := &Pattern{v: v}
+
+	val := -10.10
+	err := p.Set(0, val)
+	assert.InDelta(p.At(0), -1.0, 0.0001)
+
+	val = 10.10
+	err = p.Set(0, val)
+	assert.InDelta(p.At(0), 1.0, 0.0001)
+
+	i := 100
+	errString := "invalid index: %d"
+	err = p.Set(i, val)
+	assert.EqualError(err, fmt.Sprintf(errString, i))
+}
+
+func TestLen(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []float64{1.0, 2.0}
+	p := Encode(data)
+	assert.Equal(p.Len(), len(data))
+
+	p = Encode([]float64{})
+	assert.Equal(p.Len(), 0)
+
+	p = &Pattern{}
+	assert.Equal(p.Len(), 0)
+}
 
 func TestEncode(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
-		p        Pattern
-		expected Pattern
+		raw      []float64
+		expected []float64
 	}{
 		{[]float64{1.0, -10.0, 0.0}, []float64{1.0, -1.0, -1.0}},
 		{[]float64{1.0, 10.0}, []float64{1.0, 1.0}},
 	}
 
 	for _, tc := range testCases {
-		res := Encode(tc.p)
-		assert.EqualValues(tc.expected, res)
+		res := Encode(tc.raw)
+		assert.EqualValues(tc.expected, res.v.RawVector().Data)
 	}
 }
 
 func TestAddNoise(t *testing.T) {
 	assert := assert.New(t)
 
-	p := Pattern([]float64{1.0, 1.0, -1.0, 0.0})
+	data := []float64{1.0, 1.0, -1.0, 0.0}
+	p := Encode(data)
 	np := AddNoise(p, 50)
 
-	assert.NotEqual(p, np)
+	assert.NotEqual(p.v.RawVector().Data, np)
 }
 
 func TestImage2Pattern(t *testing.T) {
 	assert := assert.New(t)
 
 	img := image.NewGray(image.Rect(0, 0, 2, 2))
+	// draw a white image i.e. all pixels are set to 1
 	draw.Draw(img, img.Bounds(), image.White, image.ZP, draw.Src)
-	p := Image2Pattern(img)
+	imgP := Image2Pattern(img)
+	// 1-pixels are encoded to 1s
+	p := Encode([]float64{1.0, 1.0, 1.0, 1.0})
 
-	assert.Equal(Pattern{1.0, 1.0, 1.0, 1.0}, p)
+	assert.Equal(imgP, p)
 }
 
 func TestPattern2Image(t *testing.T) {
 	assert := assert.New(t)
 
-	p := Pattern([]float64{1.0, 1.0, -1.0, 0.0})
+	p := Encode([]float64{1.0, 1.0, -1.0, 0.0})
 	resImg := Pattern2Image(p, image.Rect(0, 0, 2, 2))
 
 	expImage := image.NewGray(image.Rect(0, 0, 2, 2))


### PR DESCRIPTION
Pattern now has its own API. This was necessary to avoid using non-binary values in its storage. Doing this breaks training as `Hopfield` network only works with binary state values.

Restore can now be done in two modes: sync and async. Several performance improvements have been added.

Storage functions are now network methods. Seems semantically better since they modify internal networks attributes.